### PR TITLE
Added basic IAM data collection for users, groups, roles and virtualmfadevices.

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsClient.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsClient.scala
@@ -23,6 +23,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
@@ -86,6 +87,16 @@ class AwsClient(val provider: AWSCredentialsProvider, val region: String) {
       client.setEndpoint("s3.amazonaws.com")
     else
       client.setEndpoint("s3-" + region + ".amazonaws.com")
+    client
+  }
+
+  /** get [[com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient]] object */
+  def identitymanagement = {
+    val client = new AmazonIdentityManagementClient(provider)
+    if (region == "us-gov")
+      client.setEndpoint("iam.us-gov.amazonaws.com")
+    else
+      client.setEndpoint("iam.amazonaws.com")
     client
   }
 

--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -111,6 +111,10 @@ object AwsCollectionBuilder {
       new AwsTagCollection(dsFactory, accountName, elector, ctx),
       new AwsVolumeCollection(dsFactory, accountName, elector, ctx),
       new AwsBucketCollection(dsFactory, accountName, elector, ctx),
+      new AwsIamUserCollection(dsFactory, accountName, elector, ctx),
+      new AwsIamGroupCollection(dsFactory, accountName, elector, ctx),
+      new AwsIamRoleCollection(dsFactory, accountName, elector, ctx),
+      new AwsIamVirtualMFADeviceCollection(dsFactory, accountName, elector, ctx),
       new AwsSimpleQueueCollection(dsFactory, accountName, elector, ctx),
       new AwsReservedInstanceCollection(dsFactory, accountName, elector, ctx),
       new GroupAutoScalingGroups(asg, inst, dsFactory, elector, ctx))
@@ -462,6 +466,86 @@ class AwsBucketCollection(
                            override val ctx: AwsCollection.Context) extends RootCollection("aws.buckets", accountName, ctx) {
   val dataStore: Option[DataStore] = dsFactory(name)
   val crawler = new AwsBucketCrawler(name, ctx)
+}
+
+/** collection for AWS IAM Users
+  *
+  * root collection name: aws.users
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsIamUserCrawler]]
+  *
+  * @param dsFactory function that creates new DataStore object from collection name
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for configuration and AWS clients objects
+  */
+class AwsIamUserCollection(
+                           dsFactory: String => Option[DataStore],
+                           val accountName: String,
+                           val elector: Elector,
+                           override val ctx: AwsCollection.Context) extends RootCollection("aws.users", accountName, ctx) {
+  val dataStore: Option[DataStore] = dsFactory(name)
+  val crawler = new AwsIamUserCrawler(name, ctx)
+}
+
+/** collection for AWS IAM Groups
+  *
+  * root collection name: aws.groups
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsIamGroupCrawler]]
+  *
+  * @param dsFactory function that creates new DataStore object from collection name
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for configuration and AWS clients objects
+  */
+class AwsIamGroupCollection(
+                           dsFactory: String => Option[DataStore],
+                           val accountName: String,
+                           val elector: Elector,
+                           override val ctx: AwsCollection.Context) extends RootCollection("aws.groups", accountName, ctx) {
+  val dataStore: Option[DataStore] = dsFactory(name)
+  val crawler = new AwsIamGroupCrawler(name, ctx)
+}
+
+/** collection for AWS IAM Roles
+  *
+  * root collection name: aws.roles
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsIamRoleCrawler]]
+  *
+  * @param dsFactory function that creates new DataStore object from collection name
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for configuration and AWS clients objects
+  */
+class AwsIamRoleCollection(
+                           dsFactory: String => Option[DataStore],
+                           val accountName: String,
+                           val elector: Elector,
+                           override val ctx: AwsCollection.Context) extends RootCollection("aws.roles", accountName, ctx) {
+  val dataStore: Option[DataStore] = dsFactory(name)
+  val crawler = new AwsIamRoleCrawler(name, ctx)
+}
+
+/** collection for AWS IAM VirtualMFADevices
+  *
+  * root collection name: aws.virtualmfadevices
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsIamVirtualMFADeviceCrawler]]
+  *
+  * @param dsFactory function that creates new DataStore object from collection name
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for configuration and AWS clients objects
+  */
+class AwsIamVirtualMFADeviceCollection(
+                           dsFactory: String => Option[DataStore],
+                           val accountName: String,
+                           val elector: Elector,
+                           override val ctx: AwsCollection.Context) extends RootCollection("aws.virtualmfadevices", accountName, ctx) {
+  val dataStore: Option[DataStore] = dsFactory(name)
+  val crawler = new AwsIamVirtualMFADeviceCrawler(name, ctx)
 }
 
 /** collection for AWS Simple Queue (SQS)

--- a/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
@@ -35,6 +35,15 @@ import com.amazonaws.services.ec2.model.DescribeSnapshotsRequest
 import com.amazonaws.services.ec2.model.DescribeTagsRequest
 import com.amazonaws.services.ec2.model.DescribeVolumesRequest
 
+import com.amazonaws.services.identitymanagement.model.ListUsersRequest
+import com.amazonaws.services.identitymanagement.model.ListAccessKeysRequest
+import com.amazonaws.services.identitymanagement.model.ListGroupsForUserRequest
+import com.amazonaws.services.identitymanagement.model.ListUserPoliciesRequest
+import com.amazonaws.services.identitymanagement.model.ListGroupsRequest
+import com.amazonaws.services.identitymanagement.model.ListGroupPoliciesRequest
+import com.amazonaws.services.identitymanagement.model.ListRolesRequest
+import com.amazonaws.services.identitymanagement.model.ListVirtualMFADevicesRequest
+
 import com.amazonaws.services.s3.model.ListBucketsRequest
 
 import com.amazonaws.services.sqs.model.ListQueuesRequest
@@ -512,6 +521,122 @@ class AwsBucketCrawler(val name: String, val ctx: AwsCrawler.Context) extends Cr
 
   override def doCrawl() = ctx.awsClient.s3.listBuckets(request).asScala.map(
     item => Record(item.getName, new DateTime(item.getCreationDate), ctx.beanMapper(item))).toSeq
+}
+
+/** crawler for IAM Users
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper and configuration
+  */
+class AwsIamUserCrawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler(ctx) {
+  val request = new ListUsersRequest
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+  private[this] val threadPool = Executors.newFixedThreadPool(10)
+
+  override def doCrawl() = {
+    val users = ctx.awsClient.identitymanagement.listUsers(request).getUsers.asScala
+    val futures: Seq[java.util.concurrent.Future[Record]] = users.map(
+      user => {
+        threadPool.submit(
+          new Callable[Record] {
+            def call() = {
+              val groupsRequest = new ListGroupsForUserRequest().withUserName(user.getUserName)
+              val groups = ctx.awsClient.identitymanagement.listGroupsForUser(groupsRequest).getGroups.asScala.map( item => item.getGroupName ).toSeq
+              val accessKeysRequest = new ListAccessKeysRequest().withUserName(user.getUserName)
+              val accessKeys = Map[String, String]() ++ ctx.awsClient.identitymanagement.listAccessKeys(accessKeysRequest).getAccessKeyMetadata.asScala.map(item => ctx.beanMapper(item)).toSeq
+              val userPoliciesRequest = new ListUserPoliciesRequest().withUserName(user.getUserName)
+              val userPolicies = ctx.awsClient.identitymanagement.listUserPolicies(userPoliciesRequest).getPolicyNames.asScala
+              Record(user.getUserName, new DateTime(user.getCreateDate), Map("name" -> user.getUserName, "attributes" -> (ctx.beanMapper(user)), "groups" -> groups, "accessKeys" -> accessKeys, "userPolicies" -> userPolicies))
+            }
+          }
+        )
+      }
+    )
+    val records = futures.map(
+      f => {
+        try Some(f.get)
+        catch {
+          case e: Exception => {
+            logger.error(this + "exception from IAM user sub requests", e)
+            None
+          }
+        }
+      }
+    ).collect {
+      case Some(rec) => rec
+    }
+
+    records
+  }
+
+}
+
+/** crawler for IAM Groups
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper and configuration
+  */
+class AwsIamGroupCrawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler(ctx) {
+  val request = new ListGroupsRequest
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+  private[this] val threadPool = Executors.newFixedThreadPool(10)
+
+  override def doCrawl() = {
+    val groups = ctx.awsClient.identitymanagement.listGroups(request).getGroups.asScala
+    val futures: Seq[java.util.concurrent.Future[Record]] = groups.map(
+      group => {
+        threadPool.submit(
+          new Callable[Record] {
+            def call() = {
+              val groupPoliciesRequest = new ListGroupPoliciesRequest().withGroupName(group.getGroupName)
+              val groupPolicies = ctx.awsClient.identitymanagement.listGroupPolicies(groupPoliciesRequest).getPolicyNames.asScala.toSeq
+              Record(group.getGroupName, new DateTime(group.getCreateDate), Map("name" -> group.getGroupName, "attributes" -> (ctx.beanMapper(group)), "policies" -> groupPolicies))
+            }
+          }
+        )
+      }
+    )
+    val records = futures.map(
+      f => {
+        try Some(f.get)
+        catch {
+          case e: Exception => {
+            logger.error(this + "exception from IAM listGroupPolicies", e)
+            None
+          }
+        }
+      }
+    ).collect {
+      case Some(rec) => rec
+    }
+
+    records
+  }
+
+}
+
+/** crawler for IAM Roles
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper and configuration
+  */
+class AwsIamRoleCrawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler(ctx) {
+  val request = new ListRolesRequest
+
+  override def doCrawl() = ctx.awsClient.identitymanagement.listRoles(request).getRoles.asScala.map(
+    item => Record(item.getRoleName, new DateTime(item.getCreateDate), ctx.beanMapper(item))).toSeq
+}
+
+/** crawler for IAM Virtual MFA Devices
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper and configuration
+  */
+class AwsIamVirtualMFADeviceCrawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler(ctx) {
+  val request = new ListVirtualMFADevicesRequest
+
+  override def doCrawl() = ctx.awsClient.identitymanagement.listVirtualMFADevices(request).getVirtualMFADevices.asScala.map(
+    item => Record(item.getSerialNumber.split('/').last, new DateTime(item.getEnableDate), ctx.beanMapper(item))).toSeq
 }
 
 /** crawler for SQS Queues


### PR DESCRIPTION
I've been working on basic IAM data support for Edda - the aim is to support historical records of permissions for compliance audits etc. (Obviously access to true audit trails of who changed what when would be better, but this is hopefully a good historical record.)

This is my first attempt at Scala, so I'm sure there are many minor improvements to be made before accepting this pull request.

Here are some specific things I'd like your help with / input on:
1. AwsIamUserCrawler uses futures, but actually does a few requests for more data rather than a single one. Is there a better way?
2. This code creates aws/users and aws/groups collections, which seems appropriate. How should user to group / group to user mappings be captured? At this point, I'm capturing them into the aws/users information.
3. I could not work out how to collate together extra metadata into an existing object map, so instead created parameterized maps (e.g. user data is mapped into attributes, groups, policies, etc). This feels sub-optimal, and I'd rather simply add new attributes of groups and policies to the existing set of user data fields. How can this be done?
4. Policies are difficult, since they require an extra level of fan out group > policy name > policy. Are you able to give guidance on how this can / should be accomplished?

Thanks for edda ... it really is an amazing tool and approach to a complex problem!

Nathan
