### PR TITLE
Fix for AWS credentials when using multiple accounts in configuration

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -38,12 +38,12 @@ object AwsCollectionBuilder {
     * CollectionManager.register is called for each generated collection object
     *
     * @param ctx a common collection context to be used by all collections
-    * @param clientFactory  function that takes the account and region strings and returns an AwsClient object to be used by all collections
+    * @param clientFactory  function that takes the account string and returns an AwsClient object to be used by all collections
     * @param bm beanMapper to be used by all the AWS crawlers
     * @param elector elector to be used for leadership selection
     * @param dsFactory function to return a dataStore for each collection
     */
-  def buildAll(ctx: Collection.Context, clientFactory: (String, String) => AwsClient, bm: BeanMapper, elector: Elector, dsFactory: String => Option[DataStore]) {
+  def buildAll(ctx: Collection.Context, clientFactory: (String) => AwsClient, bm: BeanMapper, elector: Elector, dsFactory: String => Option[DataStore]) {
     val collMap = Option(ctx.config.getProperty("edda.accounts")) match {
       case Some(accountString) => {
         val accounts = accountString.split(",")
@@ -52,7 +52,7 @@ object AwsCollectionBuilder {
             val config = ctx.config
             val beanMapper = bm
             val recordMatcher = ctx.recordMatcher
-            val awsClient = clientFactory(account, Utils.getProperty(config, "edda", "region", account, null))
+            val awsClient = clientFactory(account)
           }).toMap
 
         // this give us:
@@ -77,7 +77,7 @@ object AwsCollectionBuilder {
           val config = ctx.config
           val beanMapper = bm
           val recordMatcher = ctx.recordMatcher
-          val awsClient = clientFactory("", config.getProperty("edda.region", null))
+          val awsClient = clientFactory("")
         }
         mkCollections(context, "", elector, dsFactory).map(
           collection => collection.rootName -> collection).toMap

--- a/src/main/scala/com/netflix/edda/basic/BasicServer.scala
+++ b/src/main/scala/com/netflix/edda/basic/BasicServer.scala
@@ -44,13 +44,13 @@ class BasicServer extends HttpServlet {
 
     val bm = new BasicBeanMapper(BasicContext) with AwsBeanMapper
 
-    val awsClientFactory = (account: String, region: String) => {
+    val awsClientFactory = (account: String) => {
       Option(Utils.getProperty(BasicContext.config, "edda", "aws.accessKey", account, null)) match {
-        case None => new AwsClient(region)
+        case None => new AwsClient(Utils.getProperty(BasicContext.config, "edda", "region", account, null))
         case Some(accessKey) => new AwsClient(
           accessKey,
           Utils.getProperty(BasicContext.config, "edda", "aws.secretKey", account, null),
-          region)
+          Utils.getProperty(BasicContext.config, "edda", "region", account, null))
       }
     }
 


### PR DESCRIPTION
On further investigation of the issue #9 I believe there is an issue in the way BasicServer is reading the config file. It appears to always reference the base credentials rather than using the account information.

This pull request contains two separate commits. The first commit e-gineer/edda@1f788fa2eefd645c52eda8346d60fe4e2eb755a5 fixes this in the simplest possible way through use of Utils.getProperty in BasicServer. The second commit e-gineer/edda@9619afeeae9a9620bc9ba885d5886c8154462403 goes further to align the lookup of region config into the same code location.

Hopefully you can merge. Thanks.
