### PR TITLE
remove sync operations, improve logging

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,5 @@
 log4j.rootLogger=INFO, stdout, rollingFile
+log4j.category.com.netflix.edda=INFO
 
 # stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -18,6 +18,7 @@ package com.netflix.edda.aws
 import com.netflix.edda.Collection
 import com.netflix.edda.CollectionManager
 import com.netflix.edda.MergedCollection
+import com.netflix.edda.Queryable
 import com.netflix.edda.GroupCollection
 import com.netflix.edda.RootCollection
 import com.netflix.edda.Elector
@@ -542,6 +543,8 @@ class GroupAutoScalingGroups(
                               dsFactory: String => Option[DataStore],
                               val elector: Elector,
                               override val ctx: AwsCollection.Context) extends RootCollection("group.autoScalingGroups", asgCollection.accountName, ctx) with GroupCollection {
+  import Utils._
+  import Queryable._
   val crawler = asgCollection.crawler
   val dataStore: Option[DataStore] = dsFactory(name)
 
@@ -558,42 +561,49 @@ class GroupAutoScalingGroups(
     * @param oldRecords these are the previous generation of group.autoScalingGroup records
     * @return the [[com.netflix.edda.Collection.Delta]] modified from [[com.netflix.edda.GroupCollection.groupDelta]]
     */
-  override protected def delta(newRecords: Seq[Record], oldRecords: Seq[Record]) = {
+  override protected def delta(newRecords: Seq[Record], oldRecords: Seq[Record])(events: EventHandlers = DefaultEventHandlers): Nothing = {
     // newRecords will be from the ASG crawler, we need to convert it
     // to the Group records then call groupDelta
 
     val slotMap = groupSlots(oldRecords)
-
-    val instanceMap = instanceCollection.query(instanceQuery).map(rec => rec.id -> rec).toMap
-
-    val oldMap = oldRecords.map(rec => rec.id -> rec).toMap
-
-    val modNewRecords = newRecords.map(
-      asgRec => {
-        val newInstances = assignSlots(
-          AwsCollection.makeGroupInstances(asgRec, instanceMap),
-          "instanceId",
-          slotMap("instances"))
-        val asgData = asgRec.data.asInstanceOf[Map[String, Any]]
-
-        val ctime = oldMap.get(asgRec.id) match {
-          case Some(rec) => rec.ctime
-          case None => asgRec.ctime
-        }
-
-        val data = Map(
-          "desiredCapacity" -> asgData.get("desiredCapacity").getOrElse(null),
-          "instances" -> newInstances,
-          "launchConfigurationName" -> asgData.get("launchConfigurationName").getOrElse(null),
-          "loadBalancerNames" -> asgData.get("loadBalancerNames").getOrElse(List()),
-          "maxSize" -> asgData.get("maxSize").getOrElse(null),
-          "minSize" -> asgData.get("minSize").getOrElse(null),
-          "name" -> asgRec.id,
-          "start" -> ctime)
-
-        asgRec.copy(data = data)
-      })
-    super.delta(modNewRecords, oldRecords)
+    instanceCollection.query(instanceQuery) {
+      case Failure(error) => {
+        logger.error("Failed to query " + instanceCollection + ": " + error)
+        throw new java.lang.RuntimeException("Failed to query " + instanceCollection + ": " + error)
+      }
+      case Success(results: QueryResult) => {
+        val instanceMap = results.records.map(rec => rec.id -> rec).toMap
+        
+        val oldMap = oldRecords.map(rec => rec.id -> rec).toMap
+        
+        val modNewRecords = newRecords.map(
+          asgRec => {
+            val newInstances = assignSlots(
+              AwsCollection.makeGroupInstances(asgRec, instanceMap),
+              "instanceId",
+              slotMap("instances"))
+            val asgData = asgRec.data.asInstanceOf[Map[String, Any]]
+            
+            val ctime = oldMap.get(asgRec.id) match {
+              case Some(rec) => rec.ctime
+              case None => asgRec.ctime
+            }
+            
+            val data = Map(
+              "desiredCapacity" -> asgData.get("desiredCapacity").getOrElse(null),
+              "instances" -> newInstances,
+              "launchConfigurationName" -> asgData.get("launchConfigurationName").getOrElse(null),
+              "loadBalancerNames" -> asgData.get("loadBalancerNames").getOrElse(List()),
+              "maxSize" -> asgData.get("maxSize").getOrElse(null),
+              "minSize" -> asgData.get("minSize").getOrElse(null),
+              "name" -> asgRec.id,
+              "start" -> ctime)
+            
+            asgRec.copy(data = data)
+          })
+        super.delta(modNewRecords, oldRecords)(events)
+      }
+    }
   }
 }
 

--- a/src/test/scala/com/netflix/edda/MergedCollectionTest.scala
+++ b/src/test/scala/com/netflix/edda/MergedCollectionTest.scala
@@ -19,27 +19,44 @@ import org.slf4j.LoggerFactory
 
 import org.scalatest.FunSuite
 
+import scala.actors.Actor
+
 class MergedCollectionTest extends FunSuite {
+  import Utils._
+  import Queryable._
+
   val logger = LoggerFactory.getLogger(getClass)
   test("query") {
-    val collA = new TestCollection
+    val collA = new TestCollection("test.A")
     collA.dataStore.get.records = Seq(Record("a", 1), Record("b", 2), Record("c", 3))
-    val collB = new TestCollection
+    val collB = new TestCollection("test.B")
     collB.dataStore.get.records = Seq(Record("A", 1), Record("B", 2), Record("C", 3))
 
     val merged = new MergedCollection("merged.collection", Seq(collA, collB))
     merged.start()
 
-    expect(2) {
-      merged.query(Map("data" -> 1)).size
+    SYNC {
+      merged.query(Map("data" -> 1)) {
+        case Success(results: QueryResult) => {
+          expect(2) { results.records.size }
+        }
+      }
     }
 
-    expect(4) {
-      merged.query(Map("data" -> Map("$gte" -> 2))).size
+    SYNC {
+      merged.query(Map("data" -> Map("$gte" -> 2))) {
+        case Success(results: QueryResult) => {
+          expect(4) { results.records.size }
+        }
+      }
     }
 
-    expect(2) {
-      merged.query(Map("id" -> Map("$in" -> Seq("A", "a")))).size
+    SYNC {
+      merged.query(Map("id" -> Map("$in" -> Seq("A", "a")))) {
+        case Success(results: QueryResult) => {
+          expect(2) { results.records.size }
+        }
+      }
     }
   }
 }

--- a/src/test/scala/com/netflix/edda/Mocks.scala
+++ b/src/test/scala/com/netflix/edda/Mocks.scala
@@ -42,8 +42,7 @@ class TestDataStore extends DataStore {
 }
 
 
-class TestCrawler(ctx: ConfigContext) extends Crawler(ctx) {
-  val name = "TestCrawler"
+class TestCrawler(ctx: ConfigContext, val name: String = "TestCrawler") extends Crawler(ctx) {
   var records = Seq[Record]()
 
   protected def doCrawl(): Seq[Record] = records
@@ -56,9 +55,8 @@ class TestElector(ctx: ConfigContext) extends Elector(ctx) {
   protected def runElection(): Boolean = leader
 }
 
-class TestCollection extends Collection(BasicContext) {
-  val name = "test.collection"
-  val crawler = new TestCrawler(BasicContext)
+class TestCollection(val name: String = "test.collection") extends Collection(BasicContext) {
+  val crawler = new TestCrawler(BasicContext, name + " Crawler")
   val dataStore = Some(new TestDataStore)
   val elector = new TestElector(BasicContext)
 }


### PR DESCRIPTION
- fix performances issues
  - Removing the !? scala operations to prevent thread deadlock.
    -  replace sync operations with event based callbacks
  - fix load failure retry on startup
  - load from mongo slave on startup, load from master when swithing to leader
    - prevents mongo primary from getting overloaded when edda cluster starts up
- Log (debug) each sent/received actor message
