### PR TITLE
Add JVM args to gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=2.1-SNAPSHOT
-org.gradle.jvmargs="-Xmx1g -XX:MaxPermSize=256M"
+org.gradle.jvmargs=-Xmx1g -XX:MaxPermSize=256M
 org.gradle.daemon=true


### PR DESCRIPTION
I took these out of the Jenkins config and moved them to gradle.properties, partly because the Dev@Cloud setup doesn't seem to have a way to specify Java options in the job configuration, and also because anyone who clones the code will get the correct options now.
