### PR TITLE
prevent backlog of async events

### DIFF
--- a/src/main/scala/com/netflix/edda/Collection.scala
+++ b/src/main/scala/com/netflix/edda/Collection.scala
@@ -467,6 +467,9 @@ abstract class Collection(val ctx: Collection.Context) extends Queryable {
     case (SyncLoad(from), state) => {
       // SyncLoad allows us to make sure we have a current cache in memory of "live" records
       // before we take over as "Leader" and start writing to the DataStore
+      flushMessages {
+        case SyncLoad(from) => true
+      }
       val replyTo = sender
       NamedActor(this + " SyncLoad processor") {
         val records = doLoad(replicaOk = false)
@@ -480,6 +483,9 @@ abstract class Collection(val ctx: Collection.Context) extends Queryable {
       state
     }
     case (Load(from, full), state) => {
+      flushMessages {
+        case Load(from, full) => true
+      }
       NamedActor(this + " Load processor") {
           val stopwatch = loadTimer.start()
           val records = try {

--- a/src/main/scala/com/netflix/edda/Elector.scala
+++ b/src/main/scala/com/netflix/edda/Elector.scala
@@ -114,6 +114,9 @@ abstract class Elector(ctx: ConfigContext) extends Observable {
   /** handle StateMachine messages */
   private def localTransitions: PartialFunction[(Any, StateMachine.State), StateMachine.State] = {
     case (RunElection(from), state) => {
+      flushMessages {
+        case RunElection(from) => true
+      }
       Utils.NamedActor(this + " election runner") {
         val result = runElection()
         val msg = ElectionResult(this, result)


### PR DESCRIPTION
add routine to flush messages from mailbox to prevent backlog of operations that happen asynchronously.  ie prevent Crawl events queueing up so we dont hammer AWS when the backlog start processing
