### PR TITLE
db.authenticate called twice triggering exception

### DIFF
--- a/src/main/scala/com/netflix/edda/mongo/MongoDatastore.scala
+++ b/src/main/scala/com/netflix/edda/mongo/MongoDatastore.scala
@@ -169,9 +169,12 @@ object MongoDatastore {
     val db = conn.getDB(mongoProperty("database", name, "edda"))
     val user = mongoProperty("user", name, null)
     if (user != null) {
-      db.authenticate(
-        user,
-        mongoProperty("password", name, "").toArray)
+      // Fix to avoid "java.lang.IllegalStateException: can't call authenticate twice on the same DBObject"
+      if (!db.isAuthenticated()) {
+        db.authenticate(
+          user,
+          mongoProperty("password", name, "").toArray)
+      }
     }
     if (db.collectionExists(name)) db.getCollection(name) else db.createCollection(name, null)
   }


### PR DESCRIPTION
Added a check to make sure that db object is not already authenticated before calling db.authenticate(...) to avoid "java.lang.IllegalStateException: can't call authenticate twice on the same DBObject". This was preventing me from using MongoHQ, which requires authentication. After adding this fix it started working.
