### PR TITLE
Add support for AWS ElastiCache Clusters

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsClient.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsClient.scala
@@ -29,6 +29,7 @@ import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
 import com.amazonaws.services.route53.AmazonRoute53Client
 import com.amazonaws.services.rds.AmazonRDSClient
+import com.amazonaws.services.elasticache.AmazonElastiCacheClient
 
 /** provides access to AWS service client objects
   *
@@ -127,5 +128,11 @@ class AwsClient(val provider: AWSCredentialsProvider, val region: String) {
      val client = new AmazonRDSClient(provider)
      client.setEndpoint("rds.amazonaws.com")
      client
+   }
+
+   def elasticache = {
+    val client = new AmazonElastiCacheClient(provider)
+    client.setEndpoint("elasticache." + region + ".amazonaws.com")
+    client
    }
 }

--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -121,7 +121,8 @@ object AwsCollectionBuilder {
       new GroupAutoScalingGroups(asg, inst, dsFactory, elector, ctx),
       hostedZones,
       hostedRecords,
-      new AwsDatabaseCollection(dsFactory, accountName, elector, ctx)
+      new AwsDatabaseCollection(dsFactory, accountName, elector, ctx),
+      new AwsCacheClusterCollection(dsFactory, accountName, elector, ctx)
     )
   }
 }
@@ -750,3 +751,24 @@ class AwsDatabaseCollection(
   val dataStore: Option[Datastore] = dsFactory(name)
   val crawler = new AwsDatabaseCrawler(name, ctx)
 }
+
+/** collection for AWS ElastiCache clusters
+  *
+  * root collection name: aws.cacheClusters
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsCacheClusterCrawler]]
+  *
+  * @param dsFactory function that creates new Datastore object from collection name
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for AWS clients objects
+  */
+class AwsCacheClusterCollection(
+                                dsFactory: String => Option[Datastore],
+                                val accountName: String,
+                                val elector: Elector,
+                                override val ctx: AwsCollection.Context) extends RootCollection("aws.cacheClusters", accountName, ctx) {
+  val dataStore: Option[Datastore] = dsFactory(name)
+  val crawler = new AwsCacheClusterCrawler(name, ctx)
+}
+

--- a/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
@@ -71,6 +71,7 @@ import java.util.concurrent.Callable
 
 import org.slf4j.LoggerFactory
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest
+import com.amazonaws.services.elasticache.model.DescribeCacheClustersRequest
 
 /** static namespace for out Context trait */
 object AwsCrawler {
@@ -887,4 +888,16 @@ class AwsDatabaseCrawler(val name: String, val ctx: AwsCrawler.Context) extends 
 
   override def doCrawl() =  ctx.awsClient.rds.describeDBInstances(request).getDBInstances.asScala.map(
     item => Record(item.getDBInstanceIdentifier, ctx.beanMapper(item))).toSeq
+}
+
+/** crawler for ElastiCache Clusters
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper
+  */
+class AwsCacheClusterCrawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler {
+  val request = new DescribeCacheClustersRequest
+
+  override def doCrawl() = ctx.awsClient.elasticache.describeCacheClusters(request).getCacheClusters.asScala.map(
+    item => Record(item.getCacheClusterId, ctx.beanMapper(item))).toSeq
 }


### PR DESCRIPTION
Adding support for AWS ElastiCache Clusters.  This pull request adds just enough code to parse the cache cluster metadata but does not pull metadata from the actual nodes themselves.
