### PR TITLE
add S3Current datastore to track/persist live records to s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'com.sun.jersey:jersey-server:1.11'
     compile 'com.sun.jersey:jersey-servlet:1.11'
     compile 'org.slf4j:slf4j-api:1.6.4'
-    compile('com.amazonaws:aws-java-sdk:1.3.11') {
+    compile('com.amazonaws:aws-java-sdk:1.4.7') {
         exclude group:'org.codehaus.jackson'
     }
     compile 'joda-time:joda-time:2.0'
@@ -42,6 +42,7 @@ dependencies {
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'
     compile 'commons-beanutils:commons-beanutils:1.8.2'
     compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-io:commons-io:2.4'
     compile 'com.netflix.servo:servo-core:0.4.10'
     compile 'com.googlecode.java-diff-utils:diffutils:1.2.1'
 
@@ -50,6 +51,10 @@ dependencies {
     compile 'org.mongodb:mongo-java-driver:2.6.5'
     compile 'org.elasticsearch:elasticsearch:0.90.0'
     compile 'com.spatial4j:spatial4j:0.3'
+
+    // for some reason 'org.apache.httpcomponents:httpclient:4.2.1' is causing 
+    // scalac to generate 'S3ObjectInputStream.class is broken' erro
+    compile 'org.apache.httpcomponents:httpclient:4.1'
     
     testCompile 'log4j:log4j:1.2.12'
     testCompile 'org.testng:testng:6.1.1'

--- a/src/main/scala/com/netflix/edda/Utils.scala
+++ b/src/main/scala/com/netflix/edda/Utils.scala
@@ -22,6 +22,9 @@ import scala.actors.Scheduler
 import scala.actors.Exit
 
 import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPOutputStream
+import java.util.zip.GZIPInputStream
 import java.util.Date
 import java.util.Properties
 import java.text.SimpleDateFormat
@@ -44,6 +47,8 @@ import com.netflix.config.DynamicPropertyFactory
 import com.netflix.config.FixedDelayPollingScheduler
 import com.netflix.config.sources.URLConfigurationSource
 import com.netflix.config.DynamicConfiguration
+
+import org.apache.commons.io.IOUtils
 
 /** singleton object for various helper functions */
 object Utils {
@@ -416,6 +421,19 @@ object Utils {
   }
     
   def uuid = java.util.UUID.randomUUID.toString
+
+  def compress( in: String ): Array[Byte] = {
+    var out = new ByteArrayOutputStream()
+    var gzip = new GZIPOutputStream(out)
+    gzip.write(in.getBytes("UTF-8"))
+    gzip.close()
+    out.toByteArray()
+  }
+
+  def decompress( in: Array[Byte] ): String = {
+    val gis = new GZIPInputStream(new ByteArrayInputStream(in));
+    IOUtils.toString(gis, "UTF-8")
+  }
 
   def makeHistoryDatastore(name: String): Option[Datastore] = {
     Utils.getProperty("edda", "datastore.class", name, "com.netflix.edda.mongo.MongoDatastore").get match {

--- a/src/main/scala/com/netflix/edda/aws/AwsClient.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsClient.scala
@@ -32,6 +32,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
 import com.amazonaws.services.route53.AmazonRoute53Client
 import com.amazonaws.services.rds.AmazonRDSClient
 import com.amazonaws.services.elasticache.AmazonElastiCacheClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient
 
 object AwsClient {
@@ -157,6 +158,12 @@ class AwsClient(val provider: AWSCredentialsProvider, val region: String) {
     val client = new AmazonElastiCacheClient(provider)
     client.setEndpoint("elasticache." + region + ".amazonaws.com")
     client
+   }
+
+   def dynamo = {
+     val client = new AmazonDynamoDBClient(provider)
+     client.setEndpoint("dynamodb." + region + ".amazonaws.com")
+     client
    }
 
    def cloudformation = {

--- a/src/main/scala/com/netflix/edda/aws/DynamoDB.scala
+++ b/src/main/scala/com/netflix/edda/aws/DynamoDB.scala
@@ -1,0 +1,160 @@
+// /**
+//  * Copyright 2013 Netflix, Inc.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  * http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
+package com.netflix.edda.aws
+
+import org.slf4j.LoggerFactory
+
+import com.netflix.edda.RequestId
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.model._
+
+object DynamoDB {
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+  def init(tableName: String, readCap: Long, writeCap: Long)(implicit client: AmazonDynamoDBClient) {
+    this.synchronized {
+      val request = new DescribeTableRequest().withTableName(tableName)
+      var continue = true
+      while (continue) {
+        try {
+          val table: TableDescription = client.describeTable(request).getTable
+          
+          if (table.getProvisionedThroughput.getReadCapacityUnits != readCap ||
+              table.getProvisionedThroughput.getWriteCapacityUnits != writeCap ) {
+            val request = new UpdateTableRequest().withTableName(tableName).
+            withProvisionedThroughput(
+              new ProvisionedThroughput().
+                withReadCapacityUnits(readCap).
+                withWriteCapacityUnits(writeCap)
+            )
+            client.updateTable(request)
+            Thread.sleep(100)
+          }
+          
+          continue = table.getTableStatus != "ACTIVE"
+        }
+        catch {
+          case e: ResourceNotFoundException => {
+            val key = new KeySchemaElement().withAttributeName("name").withKeyType(KeyType.HASH)
+            val keyAttr = new AttributeDefinition().withAttributeName("name").withAttributeType("S")
+            val throughput = new ProvisionedThroughput().
+              withReadCapacityUnits(readCap).
+              withWriteCapacityUnits(writeCap)
+            val request = new CreateTableRequest().
+              withTableName(tableName).
+              withKeySchema(key).
+              withAttributeDefinitions(keyAttr).
+              withProvisionedThroughput(throughput)
+            client.createTable(request)
+            Thread.sleep(5000)
+          }
+          case e: ResourceInUseException =>
+            logger.error("Failed to update table", e)
+          Thread.sleep(1000)
+        }
+      }
+    }
+  }
+
+  def get(tableName: String, name: String, value: String)(implicit client: AmazonDynamoDBClient, req: RequestId): Option[Map[String,String]] = {
+    import collection.JavaConverters._
+    val getRequest = new GetItemRequest().withTableName(tableName).withKey(Map(name->new AttributeValue(value)).asJava).withConsistentRead(true)
+    var t0 = System.nanoTime()
+    val item = try {
+      client.getItem(getRequest).getItem
+    }
+    catch {
+      case e: ResourceNotFoundException => {
+        logger.error(s"$req Dynamo record for $name not found", e)
+        return None
+      }
+      case e: ProvisionedThroughputExceededException => {
+        logger.error(s"$req Dynamo table $tableName is throttled", e)
+        throw e
+      }
+      case e: Throwable => {
+        logger.error(s"$req Error getting item from dynamodb: $name", e)
+        throw e
+      }
+    } finally {
+      val t1 = System.nanoTime()
+      val lapse = (t1 - t0) / 1000000;
+      if (logger.isInfoEnabled) logger.info(s"$req dynamo read lapse: ${lapse}ms")
+    }
+
+    if( Option(item).isEmpty ) {
+      logger.error(s"$req Dynamo record for $name not found")
+      return None
+    }
+    
+    // if( Option(item).isEmpty ) {
+    //     logger.error(s"$req$this Dynamo null record for $name")
+    //     throw new java.lang.UnsupportedOperationException(s"Dynamo null record for $name")
+    // }
+    
+    Some(
+      item.asScala.map(pair => {
+        val key = pair._1
+        val attr = pair._2
+        Option(attr.getS) orElse Option(attr.getN) orElse Option(attr.getB) orElse None match {
+          case Some(value: String) => key -> value
+          case _ => throw new java.lang.RuntimeException(s"key $key is none of [String,Number,Binary] on record $value in table $tableName")
+        }
+      }).toMap
+    )
+  }
+
+  def toAttributeValue(value: Any): AttributeValue = {
+    value match {
+      case v: String => new AttributeValue().withS(v)
+      case Int|Long|Float|Double => new AttributeValue().withN(value.toString)
+      case _:java.lang.Integer|_:java.lang.Long|_:java.lang.Float|_:java.lang.Double => new AttributeValue().withN(value.toString)
+      case v: Array[Byte] => new AttributeValue().withB(java.nio.ByteBuffer.wrap(v))
+      case _ => throw new java.lang.RuntimeException(s"unable to convert ${value.getClass.getName} to DynamoDB AttributeValue")
+    }
+  }
+
+  def put(tableName: String, attributes: Map[String,Any], expected: Map[String,Any] = Map())(implicit client: AmazonDynamoDBClient, req: RequestId) = {
+    import collection.JavaConverters._
+    val t0 = System.nanoTime()
+    val request = new PutItemRequest()
+    try {
+      // write to DynamoDB
+      client.putItem(
+        request.withTableName(tableName).withItem(
+          attributes.map(pair => pair._1 -> toAttributeValue(pair._2)).toMap.asJava
+        ).withExpected(
+          expected.map(pair => {
+            val name = pair._1
+            pair._2 match {
+              case None => name -> new ExpectedAttributeValue().withExists(false)
+              case _ => name -> new ExpectedAttributeValue().withExists(true).withValue(toAttributeValue(pair._2))
+            }
+          }).toMap.asJava
+        )
+      )
+    } catch {
+      case e: Exception => {
+        logger.error(s"$req failed to update dynamodb: $request", e)
+        throw e
+      }
+    } finally {
+      val t1 = System.nanoTime()
+      val lapse = (t1 - t0) / 1000000;
+      if (logger.isInfoEnabled) logger.info(s"$req dynamo write lapse: ${lapse}ms")
+    }
+  }
+}

--- a/src/main/scala/com/netflix/edda/aws/S3CurrentDatastore.scala
+++ b/src/main/scala/com/netflix/edda/aws/S3CurrentDatastore.scala
@@ -1,0 +1,279 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.edda.aws
+
+import com.netflix.edda.Datastore
+import com.netflix.edda.RequestId
+import com.netflix.edda.Record
+import com.netflix.edda.RecordSet
+import com.netflix.edda.Collection
+import com.netflix.edda.Utils
+
+import org.slf4j.LoggerFactory
+
+import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.services.s3.model._
+
+import org.codehaus.jackson.JsonNode
+import org.codehaus.jackson.map.ObjectMapper
+
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
+import java.util.Scanner
+
+import org.apache.commons.io.IOUtils
+import org.apache.commons.codec.binary.Base64
+
+import org.joda.time.DateTime
+
+case class State(location: String, mtime: DateTime)
+
+class S3CurrentDatastore(val name: String) extends Datastore {
+  
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+
+  lazy val account = {
+    Utils.getProperty("edda", "s3current.account", name, "").get match {
+      case "" => {
+        val nameParts = name.split('.')
+        if( nameParts.size == 2 ) "" else nameParts.dropRight(2).mkString(".")
+      }
+      case acct => acct
+    }
+  }
+
+  lazy val s3     = new AwsClient(account).s3
+  val readDynamo = new AwsClient(account).dynamo
+  // disable retry's when writing to dynamo ... if initial request
+  // gets a timeout we need to know as it will likely complete eventually
+  // and then all subsequent conditional updates will fail since will be out
+  // of sync with the datastore
+  val writeDynamo = {
+    val client = new AwsClient(account).dynamo
+    val config = new com.amazonaws.ClientConfiguration().withMaxErrorRetry(0)
+    client.setConfiguration(config)
+    client
+  }
+  
+
+  lazy val tableName = Utils.getProperty("edda", "s3current.table", name, "edda-s3current-collection-index").get
+  lazy val readCap   = Utils.getProperty("edda", "s3current.readCapacity", name, "1").get.toLong
+  lazy val writeCap  = Utils.getProperty("edda", "s3current.writeCapacity", name, "1").get.toLong
+  lazy val bucketName = Utils.getProperty("edda", "s3current.bucket", name, "edda-s3current-collections").get
+
+  lazy val locationPrefix = Utils.getProperty("edda", "s3current.locationPrefix", name, "edda/s3current").get
+
+  lazy val autoDelete = Utils.getProperty("edda", "s3current.autoDelete", name, "false")
+    
+  def init() {
+    implicit var client = writeDynamo
+    s3.getBucketLocation(bucketName) match {
+      case "EU"|"eu-west-1" => s3.setEndpoint("s3-eu-west-1.amazonaws.com")
+      case "US"|"" => s3.setEndpoint("s3.amazonaws.com")
+      case location => s3.setEndpoint(s"s3-$location.amazonaws.com")
+    }
+    DynamoDB.init(tableName, readCap, writeCap)
+  }
+
+  override def load(replicaOk: Boolean)(implicit req: RequestId): RecordSet = {
+    // load once, if we get a 404 from S3, then try once more
+    try {
+      loadImpl(replicaOk)
+    } catch {
+      // object does not exist, which might mean it was just deleted, so just try to reload
+      case e: AmazonS3Exception if e.getStatusCode == 404 => {
+        loadImpl(replicaOk)
+      }
+      // if we get a socket timeout then try once more, probably a temp network glitch
+      case e: java.net.SocketTimeoutException => loadImpl(replicaOk)
+    }
+  }
+
+  def loadImpl(replicaOk: Boolean)(implicit req: RequestId): RecordSet = {
+    // load from DynamoDB
+    import collection.JavaConverters._
+    implicit var client = readDynamo
+
+    val item = DynamoDB.get(tableName, "name", name) match {
+      case Some(record: Map[String,String]) => record
+      case _ => throw new java.lang.UnsupportedOperationException(s"Dynamo record for $name not found")
+    }
+
+    val location  = item("location")
+    val requestId = item("reqId")
+    logger.info(s"$req$this Loading $name: $location ($requestId)")
+
+    // read from S3
+    val t0 = System.nanoTime()
+    var md5: String = null
+    var mtime: DateTime = DateTime.now
+    var userMeta = Map[String,String]()
+    val bytes = try {
+      val s3Object = s3.getObject(bucketName, location)
+      val meta = s3Object.getObjectMetadata();
+      mtime = new DateTime(meta.getLastModified())
+      
+      userMeta = meta.getUserMetadata().asScala.toMap
+      val origReqId = userMeta("reqid")
+      md5 = userMeta.get("md5").getOrElse("")
+      logger.info(s"$req$this Loaded $name: $location [$md5] ($origReqId) modifed: $mtime")
+      
+      val inputStream = s3Object.getObjectContent
+      var out = IOUtils.toByteArray(inputStream)
+      inputStream.close()
+      out
+    } finally {
+      val t1 = System.nanoTime()
+      val lapse = (t1 - t0) / 1000000;
+      if (logger.isInfoEnabled) logger.info(s"$req$this s3 read lapse: ${lapse}ms")
+    }
+
+    var newMD5 = Base64.encodeBase64String(MessageDigest.getInstance("MD5").digest(bytes)).trim
+    var jsonContent = if( userMeta.get("compressed").getOrElse("false").toBoolean ) {
+      Utils.decompress(bytes)
+    } else {
+      IOUtils.toString(bytes, "UTF-8")
+    }
+
+    // MD5 check content
+    if( ! md5.isEmpty ) {
+      if( md5 != newMD5 ) {
+        logger.error(s"$req$this content from s3 does not match designated md5 value, got: '$newMD5' expected: '$md5'");
+        throw new java.lang.IllegalStateException("content from s3 does not match designated md5 value")
+      }
+    }
+
+    val mapper = new ObjectMapper();
+    val jsonNode = mapper.readTree(jsonContent);
+
+    val recs = Utils.fromJson(jsonNode).asInstanceOf[Seq[Map[String,Any]]].map( node => {
+      Record(
+        node.get("id").getOrElse(node.get("_id")).asInstanceOf[String],
+        node.get("ftime") match {
+          case Some(date: Long) => new DateTime(date)
+          case _ => node.get("ctime") match {
+            case Some(date: Long) => new DateTime(date)
+            case _ => null
+          }
+        },
+        node.get("ctime") match {
+          case Some(date: Long) => new DateTime(date)
+          case _ => null
+        },
+        node.get("stime") match {
+          case Some(date: Long) => new DateTime(date)
+          case _ => null
+        },
+        node.get("ltime") match {
+          case Some(date: Long) => new DateTime(date)
+          case _ => null
+        },
+        node.get("mtime") match {
+          case Some(date: Long) => new DateTime(date)
+          case _ => null
+        },
+        node.get("data") match {
+          case Some(data) => data
+          case _ => null
+        },
+        node.get("tags") match {
+          case Some(tags) => tags.asInstanceOf[Map[String,Any]]
+          case _ => Map[String,Any]()
+        }
+      )
+    })
+    val recMtime = if( recs.isEmpty ) {
+        mtime
+      } else {
+        recs.head.mtime
+      }
+    RecordSet(recs, Map("location" -> location, "mtime" -> recMtime))
+  }
+
+  override
+  def update(d: Collection.Delta)(implicit req: RequestId): Collection.Delta = {
+    import collection.JavaConverters._
+    implicit var client = writeDynamo
+    // write to S3
+
+    val bytes = Utils.compress(Utils.toJson(d.recordSet.records))
+    val uuid = Utils.uuid
+    val location = s"$locationPrefix/$name.$uuid"
+
+    var t0 = System.nanoTime()
+    try {
+      val is = new ByteArrayInputStream(bytes)
+      val metadata = new ObjectMetadata
+      metadata.setContentLength(bytes.size)
+      metadata.setContentType("application/json")
+      val md5 = Base64.encodeBase64String(MessageDigest.getInstance("MD5").digest(bytes)).trim
+      metadata.setContentMD5(md5)
+      metadata.setUserMetadata(
+        Map("reqid" -> req.id, "md5" -> md5, "compressed" -> "true").asJava
+      )
+      val putRequest = new PutObjectRequest(bucketName, location, is, metadata)
+      s3.putObject(putRequest)
+    } finally {
+      val t1 = System.nanoTime()
+      val lapse = (t1 - t0) / 1000000;
+      if (logger.isInfoEnabled) logger.info(s"$req$this s3 write lapse: ${lapse}ms")
+    }
+    
+    val oldLocation = d.recordSet.meta.get("location") match {
+      case Some(location: String) => location
+      case _ => ""
+    }
+    
+    val attrs = Map(
+      "name" -> name,
+      "location" -> location,
+      "reqId" -> req.id
+    )
+    val expected = if( oldLocation.isEmpty ) Map( "name" -> None ) else Map( "location" -> oldLocation )
+
+    DynamoDB.put(tableName, attrs, expected);
+      
+    if( ! oldLocation.isEmpty && autoDelete.get.toBoolean ) {
+      t0 = System.nanoTime()
+      try {
+        s3.deleteObject(bucketName, oldLocation)
+      } catch {
+        case e: Exception => logger.error(s"$req$this failed to delete $oldLocation from $bucketName", e)
+      } finally {
+        val t1 = System.nanoTime()
+        val lapse = (t1 - t0) / 1000000;
+        if (logger.isInfoEnabled) logger.info(s"$req$this s3 delete lapse: ${lapse}ms")
+      }
+    }
+
+    val mtime = if( d.recordSet.records.isEmpty ) {
+        DateTime.now
+      } else {
+        d.recordSet.records.head.mtime
+      }
+    d.copy(recordSet = RecordSet(d.recordSet.records, d.recordSet.meta + ("location" -> location, "mtime" -> mtime)))
+  }
+
+  def query(queryMap: Map[String, Any], limit: Int, keys: Set[String], replicaOk: Boolean)(implicit req: RequestId): Seq[Record] = {
+    throw new java.lang.UnsupportedOperationException("you cannot query the S3 Live datastore");
+  }
+
+  def remove(queryMap: Map[String, Any])(implicit req: RequestId) {
+    throw new java.lang.UnsupportedOperationException("you cannot query the S3 Live datastore");
+  }
+    
+  override def toString = "[S3CurrentDatastore " + name + "]"
+}

--- a/src/test/scala/com/netflix/edda/basic/BasicBeanMapperTest.scala
+++ b/src/test/scala/com/netflix/edda/basic/BasicBeanMapperTest.scala
@@ -69,6 +69,7 @@ class BasicBeanMapperTest extends FunSuite {
 
 
     val expected = Map(
+      "terminationPolicies" -> List(),
       "healthCheckGracePeriod" -> 600,
       "tags" -> List(
         Map(


### PR DESCRIPTION
- adding new current datastore that tracks "live" records in s3 to make  reloading current state more
  efficient. Takes load off mongo/elasticsearch datastores.
- add dynamodb support for consistency checks on s3 reads/writes
- upgrading aws-java-sdk for dynamo support
