### PR TITLE
Fixes #34

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -744,6 +744,19 @@ class AwsDatabaseCollection(
                                val elector: Elector,
                                override val ctx: AwsCollection.Context) extends RootCollection("aws.databases", accountName, ctx) {
   val crawler = new AwsDatabaseCrawler(name, ctx)
+
+  /** this is overriden from [[com.netflix.edda.aws.Collection]] because we want to record
+    * changes, but not create new document revisions if the only changes are to latestRestorableTime values
+    */
+  override protected
+  def newStateTimeForChange(newRec: Record, oldRec: Record): Boolean = {
+    if (newRec == null || oldRec == null) return true
+    val newData = newRec.data.asInstanceOf[Map[String, Any]]
+    val oldData = oldRec.data.asInstanceOf[Map[String, Any]]
+    val newLatestRestorable = newRec.copy(data = newData.filterNot(_._1.startsWith("latestRestorable")))
+    val oldLatestRestorable = oldRec.copy(data = oldData.filterNot(_._1.startsWith("latestRestorable")))
+    newRec.data != oldRec.data && newLatestRestorable.dataString != oldLatestRestorable.dataString
+  }
 }
 
 /** collection for AWS ElastiCache clusters


### PR DESCRIPTION
I must have been sitting on this for months and it seems to work great.

Latest restorable time will only update when something else updates in the collection, for example:

```
--- /edda/api/v2/aws/databases/analytics;_pp;_at=1384218648697
+++ /edda/api/v2/aws/databases/analytics;_pp;_at=1384219127312
@@ -22,1 +22,1 @@
-  "autoMinorVersionUpgrade" : true,
+  "autoMinorVersionUpgrade" : false,
@@ -36,1 +36,1 @@
-  "latestRestorableTime" : "2013-11-12T01:10:00.000Z",
+  "latestRestorableTime" : "2013-11-12T01:15:00.000Z",
```
