### PR TITLE
added autoscaling describeScalingActivities support

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -127,7 +127,8 @@ object AwsCollectionBuilder {
       new AwsDatabaseCollection(accountName, elector, ctx),
       new AwsCacheClusterCollection(accountName, elector, ctx),
       new AwsSubnetCollection(accountName, elector, ctx),
-      new AwsCloudformationCollection(accountName, elector, ctx)
+      new AwsCloudformationCollection(accountName, elector, ctx),
+      new AwsScalingActivitiesCollection(accountName, elector, ctx)
     )
   }
 }
@@ -243,6 +244,23 @@ class AwsAlarmCollection(
                                      val elector: Elector,
                                      override val ctx: AwsCollection.Context) extends RootCollection("aws.alarms", accountName, ctx) {
   val crawler = new AwsAlarmCrawler(name, ctx)
+}
+
+/** collection for AWS AutoScaling Activities
+  *
+  * root collection name: aws.scalingActivities
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsScalingActivitiesCrawler]]
+  *
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for AWS clients objects
+  */
+class AwsScalingActivitiesCollection(
+                               val accountName: String,
+                               val elector: Elector,
+                               override val ctx: AwsCollection.Context) extends RootCollection("aws.scalingActivities", accountName, ctx) {
+  val crawler = new AwsScalingActivitiesCrawler(name, ctx)
 }
 
 /** collection for AWS Images

--- a/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
@@ -62,6 +62,7 @@ import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsRequest
 import com.amazonaws.services.autoscaling.model.DescribePoliciesRequest
+import com.amazonaws.services.autoscaling.model.DescribeScalingActivitiesRequest
 
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
 import com.amazonaws.services.elasticloadbalancing.model.DescribeInstanceHealthRequest
@@ -211,6 +212,31 @@ class AwsScalingPolicyCrawler(val name: String, val ctx: AwsCrawler.Context) ext
         response.getScalingPolicies.asScala.map(
           item => {
             Record(item.getPolicyName, ctx.beanMapper(item))
+          }).toList
+      }
+    }
+    it.toList.flatten
+  }
+}
+
+/** crawler for ASG Activities
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper
+  */
+class AwsScalingActivitiesCrawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler {
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+  val request = new DescribeScalingActivitiesRequest
+  request.setMaxRecords(50)
+
+  override def doCrawl()(implicit req: RequestId) = {
+    val it = new AwsIterator() {
+      def next() = {
+        val response = ctx.awsClient.asg.describeScalingActivities(request.withNextToken(this.nextToken.get))
+        this.nextToken = Option(response.getNextToken)
+        response.getActivities.asScala.map(
+          item => {
+            Record(item.getActivityId, ctx.beanMapper(item))
           }).toList
       }
     }


### PR DESCRIPTION
The ID here is a guid (maybe I'll get un-annoyed by this one day):
```
{
activityId: "c1111e1e-1b11-11fe-1da1-fd11a111e1cf",
autoScalingGroupName: "asgname",
cause: "At 2013-11-11T11:11:11Z a monitor alarm asg-alarm-name in state ALARM triggered policy asg-policy-up changing the desired capacity from 1 to 2. At 2013-11-11T11:11:11Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 1 to 2.",
class: "com.amazonaws.services.autoscaling.model.Activity",
description: "Launching a new EC2 instance: i-abcdef78",
details: "{"InvokingAlarms":[{"Region":"US - N. Virginia","OldStateValue":"OK","AWSAccountId":"blahblah","AlarmName":"asg-alarm-name","AlarmDescription":null,"StateChangeTime":1385746272474,"NewStateReason":"Threshold Crossed: 1 datapoint (85.679) was greater than or equal to the threshold (85.0).","NewStateValue":"ALARM","Trigger":{"Period":300,"Statistic":"AVERAGE","MetricName":"CPUUtilization","Threshold":85,"EvaluationPeriods":1,"Dimensions":[{"name":"AutoScalingGroupName","value":"asgname"}],"Namespace":"AWS/EC2","ComparisonOperator":"GreaterThanOrEqualToThreshold","Unit":null}}],"Availability Zone":"us-east-1d"}",
endTime: 1385746425000,
progress: 100,
startTime: 1385746301644,
statusCode: "Successful",
statusMessage: null
}
```
Also, Details looks like it's being mapped as a string which I'd like to parse out to seperate fields but I'm not sure how dynamic that data is yet or if it's usable as is.