### PR TITLE
collection discovery / HATEOS

### DIFF
--- a/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
+++ b/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
@@ -422,8 +422,8 @@ class CollectionResource {
 
   /** allow browsing of collections to enable RESTful discovery */
   @GET
-  @Path("/browse")
-  def browse(@Context req: HttpServletRequest): Response = {
+  @Path("/index")
+  def index(@Context req: HttpServletRequest): Response = {
     val t0 = System.nanoTime()
     // +4 for length("/v2/")
     val realPath = req.getRequestURI.drop(req.getContextPath.length + req.getServletPath.length + 4)
@@ -443,6 +443,8 @@ class CollectionResource {
       if (logger.isInfoEnabled) logger.info(reqId.toString + "EXIT " + realPath  + " lapse " + lapse + "ms")
     }
   }
+
+  /** TODO: replace this with a templating engine */
   def buildCollectionUrls(): String = {
     val prefix = "<html><body>Collections<br/>"
     

--- a/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
+++ b/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
@@ -419,5 +419,37 @@ class CollectionResource {
       if (logger.isInfoEnabled) logger.info(reqId.toString + "EXIT " + realPath  + " lapse " + lapse + "ms")
     }
   }
+
+  /** allow browsing of collections to enable RESTful discovery */
+  @GET
+  @Path("/browse")
+  def browse(@Context req: HttpServletRequest): Response = {
+    val t0 = System.nanoTime()
+    // +4 for length("/v2/")
+    val realPath = req.getRequestURI.drop(req.getContextPath.length + req.getServletPath.length + 4)
+    reqId = RequestId()
+    logger.info(reqId.toString + "GET " + realPath)
+    try {
+      val output = buildCollectionUrls()
+      Response.
+            status(Response.Status.OK).
+            `type`(MediaType.TEXT_HTML).
+            entity(output).
+            header("X-Request-Id", reqId.id).
+            build()
+      } finally {
+      val t1 = System.nanoTime()
+      val lapse = (t1 - t0) / 1000000;
+      if (logger.isInfoEnabled) logger.info(reqId.toString + "EXIT " + realPath  + " lapse " + lapse + "ms")
+    }
+  }
+  def buildCollectionUrls(): String = {
+    val prefix = "<html><body>Collections<br/>"
+    
+    val suffix = "</body></html>"
+    val names = CollectionManager.names().map(x => x.replace(".","/"))
+    prefix + names.map(x => "<a href=\"" + x + "\">" + x + "</a>").mkString("<br/>") + suffix
+  }
+
     
 }


### PR DESCRIPTION
This isn't intended to be merge-able but I wanted to open up discussion around templating vs embedding 'action' URLs in the JSON responses.  I think both approaches have their relative merits.

Templating:
  Convention based exposure of simple collection traversal along with basic time navigation.  Relies on yet-to-be-built ( https://twitter.com/ralphtice/status/407503357016686593 ) UI for field selectors.

Embedding 'action' URLs:
  Provides URLs within the JSON responses for simple navigation actions, allows better composition (live inside someone else's UI) but still defers the bulk of complexity plus a simple reference architecture. ex:
{ ...
 'referenceUrl' => '//edda/api/v2/aws/collection/documentId'
 'previousDocumentUrl' => '//edda/api/v2/aws/collection/documentId?_at=123123'
 ...
}
We could also combine both approaches -- provide a basic HTML/js view that consumes Edda collections that contain action URLs.  I think I am leaning towards this approach since it provides a nice separation between HTML and code and can exist on its own rather than cluttering up the 'API' repo.

Thoughts?