### PR TITLE
Allow for spaces in request URL

### DIFF
--- a/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
+++ b/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.{GET, Path}
 import javax.ws.rs.core.{Response, Context, MediaType}
 import java.io.ByteArrayOutputStream
+import java.net.URLDecoder
 
 import com.netflix.edda.web.FieldSelectorParser
 import com.netflix.edda.web.FieldSelectorExpr
@@ -148,9 +149,14 @@ class CollectionResource {
   /** companion object to handle matrix arguments */
   object ReqDetails {
     def apply(req: HttpServletRequest, id: String, matrixStr: String, exprStr: String): ReqDetails = {
-      val args: Map[String, String] = Utils.parseMatrixArguments(matrixStr)
-      val expr = if (exprStr == null) MatchAnyExpr
-      else FieldSelectorParser.parse(exprStr)
+      val dmatrixStr = if (matrixStr == null) null
+      else URLDecoder.decode(matrixStr, "UTF-8")
+      val dexprStr = if (exprStr == null) null
+      else URLDecoder.decode(exprStr, "UTF-8")
+
+      val args: Map[String, String] = Utils.parseMatrixArguments(dmatrixStr)
+      val expr = if (dexprStr == null) MatchAnyExpr
+      else FieldSelectorParser.parse(dexprStr)
 
       val metaArgs = args.filter(t => t._1.head == '_')
       val matrixArgs = args.filter(t => t._1.head != '_')

--- a/src/main/scala/com/netflix/edda/web/FieldSelectorParser.scala
+++ b/src/main/scala/com/netflix/edda/web/FieldSelectorParser.scala
@@ -138,7 +138,6 @@ object FieldSelectorParser {
 }
 
 class FieldSelectorParser extends RegexParsers {
-
   def expression: Parser[FieldSelectorExpr] = flattenExpr | keySelectExpr
 
   def keySelectExpr = ":(" ~> repsep(subExpr, ",") <~ ")" ^^ (values => {
@@ -164,7 +163,7 @@ class FieldSelectorParser extends RegexParsers {
 
   def invRegexExpr = "!~" ~> regexLiteral ^^ (value => RegexExpr(value, invert = true))
 
-  def id = regex("[a-zA-Z0-9_\\.\\-]*".r)
+  def id = regex("[a-zA-Z0-9_\\.\\-]*[\\s]*[a-zA-Z0-9_\\.\\-]*".r)
 
   def literalExpr =
     stringLiteral |


### PR DESCRIPTION
These changes allow spaces in arguments in the URL request (mainly for custom tags).

For example:

"http://edda/view/instances;tags.Some Tag=This Value;_expand:(tags:(Another Tagname))"

would be encoded by a browser before submission as:

"http://edda/view/instances;tags.Some%20Tag=This%20Value;_expand:(tags:(Another%20Tagname))"

These changes URLDecode the query string, and also allow the expressions in Field Selector to contain spaces.


