### PR TITLE
Upgrade scala to enable support for Oracle Java 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,12 +66,12 @@ dependencies {
     providedCompile 'javax.servlet:servlet-api:2.5'
 
     // Libraries needed to run the scala tools
-    scalaTools 'org.scala-lang:scala-compiler:2.10.1'
-    scalaTools 'org.scala-lang:scala-library:2.10.1'
+    scalaTools 'org.scala-lang:scala-compiler:2.10.3'
+    scalaTools 'org.scala-lang:scala-library:2.10.3'
 
     // Libraries needed for scala api
-    compile 'org.scala-lang:scala-library:2.10.1'
-    compile 'org.scala-lang:scala-actors:2.10.1'
+    compile 'org.scala-lang:scala-library:2.10.3'
+    compile 'org.scala-lang:scala-actors:2.10.3'
 }
 
 test << {


### PR DESCRIPTION
The version of scala referenced in build.gradle, 2.10.1 does not support
Oracle Java 8, resulting in compilation errors. Scala supports Java 8 from
version 2.10.3. Therefore, we change the version from 2.10.1 to 2.10.3.

Signed-off-by: Thorsten Fischer thorsten@froschi.org
