### PR TITLE
Update ElasticSearch dependency to 0.90.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     compile 'com.netflix.archaius:archaius-core:0.5.6'
 
     compile 'org.mongodb:mongo-java-driver:2.6.5'
-    compile 'org.elasticsearch:elasticsearch:0.90.0'
+    compile 'org.elasticsearch:elasticsearch:0.90.3'
     compile 'com.spatial4j:spatial4j:0.3'
 
     // for some reason 'org.apache.httpcomponents:httpclient:4.2.1' is causing 


### PR DESCRIPTION
This is the latest dependency of ES that doesn't require any code changes.