### PR TITLE
fix rds client url so edda can see multiple regions

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsClient.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsClient.scala
@@ -157,7 +157,7 @@ class AwsClient(val provider: AWSCredentialsProvider, val region: String) {
 
    def rds = {
      val client = new AmazonRDSClient(provider)
-     client.setEndpoint("rds.amazonaws.com")
+     client.setEndpoint("rds." + region + ".amazonaws.com")
      client
    }
 


### PR DESCRIPTION
Edda appears to always read the default region for the SDK since it always talks to the rds.amazonaws.com URL.