### PR TITLE
add build tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,8 @@ coverage:
 license:
 	$(SBT) formatLicenseHeaders
 
+test:
+	$(SBT) test
+
+war:
+	$(SBT) checkLicenseHeaders package

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,9 @@ lazy val edda = project.in(file("."))
 
     "javax.servlet"                  % "servlet-api"              % "2.5"   % "provided",
 
-    "log4j"                          % "log4j"                    % log4j   % "test",
-    "org.scalatest"                 %% "scalatest"                % "2.2.6" % "test",
-    "org.slf4j"                      % "slf4j-log4j12"            % slf4j   % "test"
+    "log4j"                          % "log4j"                    % log4j,
+    "org.slf4j"                      % "slf4j-log4j12"            % slf4j,
+
+    "org.scalatest"                 %% "scalatest"                % "2.2.6" % "test"
   ))
 


### PR DESCRIPTION
adding build tasks and restoring log4j; this puts log4j in the war file I'm deploying.  if there is a better way to do this I'm all ears.