### PR TITLE
bump dependency on AWS SDK to 1.11.60

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-val aws        = "1.11.22"
+val aws        = "1.11.60"
 val jackson    = "1.9.2"
 val jersey     = "1.11"
 val log4j      = "1.2.12"

--- a/src/test/scala/com/netflix/edda/basic/BasicBeanMapperTest.scala
+++ b/src/test/scala/com/netflix/edda/basic/BasicBeanMapperTest.scala
@@ -109,7 +109,8 @@ class BasicBeanMapperTest extends FunSuite {
       "availabilityZones" -> List("us-east-1c"),
       "autoScalingGroupName" -> "asgName",
       "minSize" -> 2,
-      "launchConfigurationName" -> "launchConfigName"
+      "launchConfigurationName" -> "launchConfigName",
+      "targetGroupARNs" -> List()
     )
 
     expectResult(expected) {


### PR DESCRIPTION
This allows us to collect targetGroupARNs from AutoScalingGroups (among other things)