### PR TITLE
Add support for elbv2

### DIFF
--- a/src/main/scala/com/netflix/edda/aws/AwsClient.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsClient.scala
@@ -27,6 +27,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.ec2.AmazonEC2Client
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
+import com.amazonaws.services.elasticloadbalancingv2.{AmazonElasticLoadBalancingClient => AmazonElasticLoadBalancingV2Client}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.sqs.AmazonSQSClient
@@ -133,6 +134,13 @@ class AwsClient(val provider: AWSCredentialsProvider, val region: String) {
   /** get [[http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/elasticloadbalancing/AmazonElasticLoadBalancingClient.html com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient]] object */
   def elb = {
     val client = new AmazonElasticLoadBalancingClient(provider)
+    client.setEndpoint("elasticloadbalancing." + region + ".amazonaws.com")
+    client
+  }
+
+  /** get [[http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/elasticloadbalancingv2/AmazonElasticLoadBalancingClient.html com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient]] object */
+  def elbv2 = {
+    val client = new AmazonElasticLoadBalancingV2Client(provider)
     client.setEndpoint("elasticloadbalancing." + region + ".amazonaws.com")
     client
   }

--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -130,10 +130,11 @@ object AwsCollectionBuilder {
       new AwsCacheClusterCollection(accountName, elector, ctx),
       new AwsSubnetCollection(accountName, elector, ctx),
       new AwsCloudformationCollection(accountName, elector, ctx),
-			new AwsScalingActivitiesCollection(accountName, elector, ctx),
-			new AwsScheduledActionsCollection(accountName, elector, ctx),
-			new AwsVpcCollection(accountName, elector, ctx),
-			new AwsReservedInstancesOfferingCollection(accountName, elector, ctx)
+      new AwsScalingActivitiesCollection(accountName, elector, ctx),
+      new AwsScheduledActionsCollection(accountName, elector, ctx),
+      new AwsVpcCollection(accountName, elector, ctx),
+      new AwsReservedInstancesOfferingCollection(accountName, elector, ctx),
+      new AwsLoadBalancerV2Collection(accountName, elector, ctx)
     )
   }
 }
@@ -351,6 +352,23 @@ class AwsLoadBalancerCollection(
                                  val elector: Elector,
                                  override val ctx: AwsCollection.Context) extends RootCollection("aws.loadBalancers", accountName, ctx) {
   val crawler = new AwsLoadBalancerCrawler(name, ctx)
+}
+
+/** collection for AWS Elastic Load Balancers (version 2)
+  *
+  * root collection name: aws.loadBalancersV2
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsLoadBalancerV2Crawler]]
+  *
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for AWS clients objects
+  */
+class AwsLoadBalancerV2Collection(
+                                 val accountName: String,
+                                 val elector: Elector,
+                                 override val ctx: AwsCollection.Context) extends RootCollection("aws.loadBalancersV2", accountName, ctx) {
+  val crawler = new AwsLoadBalancerV2Crawler(name, ctx)
 }
 
 /** collection for AWS Elastic Load Balancer Instances

--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -134,7 +134,8 @@ object AwsCollectionBuilder {
       new AwsScheduledActionsCollection(accountName, elector, ctx),
       new AwsVpcCollection(accountName, elector, ctx),
       new AwsReservedInstancesOfferingCollection(accountName, elector, ctx),
-      new AwsLoadBalancerV2Collection(accountName, elector, ctx)
+      new AwsLoadBalancerV2Collection(accountName, elector, ctx),
+      new AwsTargetGroupCollection(accountName, elector, ctx)
     )
   }
 }
@@ -369,6 +370,23 @@ class AwsLoadBalancerV2Collection(
                                  val elector: Elector,
                                  override val ctx: AwsCollection.Context) extends RootCollection("aws.loadBalancersV2", accountName, ctx) {
   val crawler = new AwsLoadBalancerV2Crawler(name, ctx)
+}
+
+/** collection for AWS Target Groups
+  *
+  * root collection name: aws.targetGroups
+  *
+  * see crawler details [[com.netflix.edda.aws.AwsTargetGroupCrawler]]
+  *
+  * @param accountName account name to be prefixed to collection name
+  * @param elector Elector to determine leadership
+  * @param ctx context for AWS clients objects
+  */
+class AwsTargetGroupCollection(
+                                   val accountName: String,
+                                   val elector: Elector,
+                                   override val ctx: AwsCollection.Context) extends RootCollection("aws.targetGroups", accountName, ctx) {
+  val crawler = new AwsTargetGroupCrawler(name, ctx)
 }
 
 /** collection for AWS Elastic Load Balancer Instances

--- a/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
@@ -54,6 +54,8 @@ import com.amazonaws.services.autoscaling.model.DescribeScalingActivitiesRequest
 import com.amazonaws.services.autoscaling.model.DescribeScheduledActionsRequest
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
 import com.amazonaws.services.elasticloadbalancing.model.DescribeInstanceHealthRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeListenersRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.{DescribeLoadBalancersRequest => DescribeLoadBalancersV2Request}
 import com.amazonaws.services.route53.model.ListHostedZonesRequest
 import com.amazonaws.services.route53.model.ListResourceRecordSetsRequest
 
@@ -339,6 +341,39 @@ class AwsLoadBalancerCrawler(val name: String, val ctx: AwsCrawler.Context) exte
 
   override def doCrawl()(implicit req: RequestId) = backoffRequest { ctx.awsClient.elb.describeLoadBalancers(request).getLoadBalancerDescriptions }.asScala.map(
     item => Record(item.getLoadBalancerName, new DateTime(item.getCreatedTime), ctx.beanMapper(item))).toSeq
+}
+
+/** crawler for LoadBalancers (version 2)
+  *
+  * @param name name of collection we are crawling for
+  * @param ctx context to provide beanMapper
+  */
+class AwsLoadBalancerV2Crawler(val name: String, val ctx: AwsCrawler.Context) extends Crawler {
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+  val request = new DescribeLoadBalancersV2Request
+
+  override def doCrawl()(implicit req: RequestId) = {
+    val it = new AwsIterator {
+      override def next() = {
+        val response = backoffRequest {
+          ctx.awsClient.elbv2.describeLoadBalancers(request.withMarker(this.nextToken.get))
+        }
+        this.nextToken = Option(response.getNextMarker)
+        response.getLoadBalancers.asScala.map(
+          item => {
+            val lr = new DescribeListenersRequest().withLoadBalancerArn(item.getLoadBalancerArn)
+            val listeners = backoffRequest { ctx.awsClient.elbv2.describeListeners(lr) }.getListeners
+            // If there are no listeners AWS returns null instead of an empty list
+            val listenersList = if (listeners == null) Nil else listeners.asScala.map(item => ctx.beanMapper(item)).toList
+            val data = ctx.beanMapper(item).asInstanceOf[Map[String, Any]] ++ Map("listeners" -> listenersList)
+
+            Record(item.getLoadBalancerName, new DateTime(item.getCreatedTime), data)
+          }
+        ).toList
+      }
+    }
+    it.toList.flatten
+  }
 }
 
 case class AwsInstanceHealthCrawlerState(elbRecords: Seq[Record] = Seq[Record]())


### PR DESCRIPTION
This PR adds crawlers for V2 load balancers and target groups. Listeners are merged into the LB as they don't exist independently of the LB (unlike target groups) 