### PR TITLE
Update Build Status Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Netflix/edda.svg)](https://travis-ci.org/Netflix/edda/builds)
+[![Build Status](https://travis-ci.com/Netflix/edda.svg)](https://travis-ci.com/Netflix/edda/builds)
 
 ## DESCRIPTION
 

--- a/src/main/scala/com/netflix/edda/BeanMapper.scala
+++ b/src/main/scala/com/netflix/edda/BeanMapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Collection.scala
+++ b/src/main/scala/com/netflix/edda/Collection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/CollectionManager.scala
+++ b/src/main/scala/com/netflix/edda/CollectionManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/CollectionProcessor.scala
+++ b/src/main/scala/com/netflix/edda/CollectionProcessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/CollectionRefresher.scala
+++ b/src/main/scala/com/netflix/edda/CollectionRefresher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Crawler.scala
+++ b/src/main/scala/com/netflix/edda/Crawler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Datastore.scala
+++ b/src/main/scala/com/netflix/edda/Datastore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Elector.scala
+++ b/src/main/scala/com/netflix/edda/Elector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/ElectorPoller.scala
+++ b/src/main/scala/com/netflix/edda/ElectorPoller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/ExecutionContexts.scala
+++ b/src/main/scala/com/netflix/edda/ExecutionContexts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/FileElector.scala
+++ b/src/main/scala/com/netflix/edda/FileElector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/GroupCollection.scala
+++ b/src/main/scala/com/netflix/edda/GroupCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/MergedCollection.scala
+++ b/src/main/scala/com/netflix/edda/MergedCollection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Observable.scala
+++ b/src/main/scala/com/netflix/edda/Observable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Queryable.scala
+++ b/src/main/scala/com/netflix/edda/Queryable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Record.scala
+++ b/src/main/scala/com/netflix/edda/Record.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/RecordMatcher.scala
+++ b/src/main/scala/com/netflix/edda/RecordMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/RequestId.scala
+++ b/src/main/scala/com/netflix/edda/RequestId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/StateMachine.scala
+++ b/src/main/scala/com/netflix/edda/StateMachine.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/Utils.scala
+++ b/src/main/scala/com/netflix/edda/Utils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/aws/AwsClient.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCollections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
+++ b/src/main/scala/com/netflix/edda/aws/AwsCrawlers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/aws/DynamoDB.scala
+++ b/src/main/scala/com/netflix/edda/aws/DynamoDB.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/aws/DynamoDBElector.scala
+++ b/src/main/scala/com/netflix/edda/aws/DynamoDBElector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/aws/S3CurrentDatastore.scala
+++ b/src/main/scala/com/netflix/edda/aws/S3CurrentDatastore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/basic/BasicBeanMapper.scala
+++ b/src/main/scala/com/netflix/edda/basic/BasicBeanMapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/basic/BasicContext.scala
+++ b/src/main/scala/com/netflix/edda/basic/BasicContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/basic/BasicRecordMatcher.scala
+++ b/src/main/scala/com/netflix/edda/basic/BasicRecordMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/basic/BasicServer.scala
+++ b/src/main/scala/com/netflix/edda/basic/BasicServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/elasticsearch/ElasticSearchDatastore.scala
+++ b/src/main/scala/com/netflix/edda/elasticsearch/ElasticSearchDatastore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/elasticsearch/ElasticSearchElector.scala
+++ b/src/main/scala/com/netflix/edda/elasticsearch/ElasticSearchElector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/mongo/MongoDatastore.scala
+++ b/src/main/scala/com/netflix/edda/mongo/MongoDatastore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/mongo/MongoElector.scala
+++ b/src/main/scala/com/netflix/edda/mongo/MongoElector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
+++ b/src/main/scala/com/netflix/edda/resources/CollectionResource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/netflix/edda/web/FieldSelectorParser.scala
+++ b/src/main/scala/com/netflix/edda/web/FieldSelectorParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/CollectionTest.scala
+++ b/src/test/scala/com/netflix/edda/CollectionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/MergedCollectionTest.scala
+++ b/src/test/scala/com/netflix/edda/MergedCollectionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/Mocks.scala
+++ b/src/test/scala/com/netflix/edda/Mocks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/RecordTest.scala
+++ b/src/test/scala/com/netflix/edda/RecordTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/StateMachineTest.scala
+++ b/src/test/scala/com/netflix/edda/StateMachineTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/UtilsTest.scala
+++ b/src/test/scala/com/netflix/edda/UtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/basic/BasicBeanMapperTest.scala
+++ b/src/test/scala/com/netflix/edda/basic/BasicBeanMapperTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/basic/BasicRecordMatcherTest.scala
+++ b/src/test/scala/com/netflix/edda/basic/BasicRecordMatcherTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/web/FieldSelectorExprTest.scala
+++ b/src/test/scala/com/netflix/edda/web/FieldSelectorExprTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/netflix/edda/web/FieldSelectorParserTest.scala
+++ b/src/test/scala/com/netflix/edda/web/FieldSelectorParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 Netflix, Inc.
+ * Copyright 2012-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).

The most recent build failed because of license headers. This change also updates license headers (similar to #128) in an effort to get the build green.